### PR TITLE
9067 Support PMBR customisation with EFI label

### DIFF
--- a/exception_lists/copyright
+++ b/exception_lists/copyright
@@ -23,6 +23,7 @@
 # Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 # Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2011 by Delphix. All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
 
 syntax: glob
@@ -99,6 +100,8 @@ usr/src/common/bzip2/decompress.c
 usr/src/common/bzip2/bzlib_private.h
 usr/src/common/bzip2/huffman.c
 usr/src/common/ficl/*
+usr/src/data/hwdata/THIRDPARTYLICENSE.efifixes.descrip
+usr/src/data/hwdata/THIRDPARTYLICENSE.efifixes.tmpl
 usr/src/grub/grub-0.97/stage2/Makefile.am
 usr/src/grub/grub-0.97/stage2/builtins.c
 usr/src/grub/grub-0.97/stage2/disk_io.c

--- a/usr/src/data/hwdata/Makefile
+++ b/usr/src/data/hwdata/Makefile
@@ -22,24 +22,30 @@
 #
 # Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
 
 include		$(SRC)/data/Makefile.data
 
-HWDATA=		pci.ids usb.ids
+HWDATA=		pci.ids usb.ids efi.fixes
 HWDATADIR=	$(ROOT)/usr/share/hwdata
 ROOTHWDATA=	$(HWDATA:%=$(HWDATADIR)/%)
 
-CLOBBERFILES=	THIRDPARTYLICENSE.pciids
+CLOBBERFILES=	THIRDPARTYLICENSE.pciids THIRDPARTYLICENSE.efifixes
 
 $(ROOTHWDATA):=	FILEMODE = 444
 
-all install:	THIRDPARTYLICENSE.pciids
+all install:	THIRDPARTYLICENSE.pciids THIRDPARTYLICENSE.efifixes
 
 THIRDPARTYLICENSE.pciids: pci.ids THIRDPARTYLICENSE.pciids.tmpl
 		$(RM) $@
 		$(SED) -e '/^$$/,$$ d' < pci.ids > $@
 		$(CAT) THIRDPARTYLICENSE.pciids.tmpl >> $@
+
+THIRDPARTYLICENSE.efifixes: efi.fixes THIRDPARTYLICENSE.efifixes.tmpl
+		$(RM) $@
+		$(SED) -e '/^$$/,$$ d' < efi.fixes > $@
+		$(CAT) THIRDPARTYLICENSE.efifixes.tmpl >> $@
 
 install:	$(ROOTHWDATA)
 

--- a/usr/src/data/hwdata/THIRDPARTYLICENSE.efifixes.descrip
+++ b/usr/src/data/hwdata/THIRDPARTYLICENSE.efifixes.descrip
@@ -1,0 +1,1 @@
+EFIFIXES

--- a/usr/src/data/hwdata/THIRDPARTYLICENSE.efifixes.tmpl
+++ b/usr/src/data/hwdata/THIRDPARTYLICENSE.efifixes.tmpl
@@ -1,0 +1,30 @@
+
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) [year] [your name]
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * [id for your version control system, if any]
+ */

--- a/usr/src/data/hwdata/efi.fixes
+++ b/usr/src/data/hwdata/efi.fixes
@@ -1,0 +1,72 @@
+# This file contains definitions of systems which are known to have problems
+# booting from an EFI/GPT partitioned disk, and the workaround. It is used
+# by libefi to change the way in which the protective master-boot-record (PMBR)
+# is written to the disk when the EFI label changes.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+# Copyright (c) 2016 Allan Jude <allanjude@freebsd.org>
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+
+# Each line consists of a number of whitespace delimited name=value pairs
+# which define conditions for the host system which are matched against values
+# in SMBIOS tables. These are followed by actions to take if the host system
+# matches; more than one action can be specified.
+#
+# Conditions:
+#  From the SMB_TYPE_SYSTEM table (`smbios -t SMB_TYPE_SYSTEM`)
+#	sys.manufacturer
+#	sys.product
+#	sys.version
+#  From the SMB_TYPE_BASEBOARD table (`smbios -t SMB_TYPE_BASEBOARD`)
+#	mb.manufacturer
+#	mb.product
+#	mb.version
+#
+# Actions:
+#	pmbr_slot=n     0 <= n <= 3     (default 0)
+#		Place the EFI partition entry into slot n in the PMBR
+#	pmbr_active=n   0 <= n <= 1     (default 0)
+#		Mark the EFI partition as active within the PMBR
+
+# References:
+#   https://lists.freebsd.org/pipermail/freebsd-i386/2013-March/010437.html
+#   https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=194359
+
+sys.manufacturer="Lenovo" sys.version="ThinkPad X220"		pmbr_slot=1
+sys.manufacturer="Lenovo" sys.version="ThinkPad T420"		pmbr_slot=1
+sys.manufacturer="Lenovo" sys.version="ThinkPad T520"		pmbr_slot=1
+sys.manufacturer="Lenovo" sys.version="ThinkPad W520"		pmbr_slot=1
+sys.manufacturer="Lenovo" sys.version="ThinkPad X1"		pmbr_slot=1
+
+sys.manufacturer="Dell Inc." sys.product="Latitude E6330"	pmbr_active=1
+sys.manufacturer="Dell Inc." sys.product="Latitude E7440"	pmbr_active=1
+sys.manufacturer="Dell Inc." sys.product="Latitude E7240"	pmbr_active=1
+sys.manufacturer="Dell Inc." sys.product="Precision Tower 5810"	pmbr_active=1
+
+sys.manufacturer="Hewlett-Packard" sys.product="HP ProBook 4330s" pmbr_active=1
+
+mb.manufacturer="Intel Corporation" mb.product="DP965LT"	pmbr_active=1
+mb.manufacturer="Intel Corporation" mb.product="D510MO"		pmbr_active=1
+
+mb.manufacturer="Acer" mb.product="Veriton M6630G"		pmbr_active=1
+

--- a/usr/src/lib/libefi/Makefile.com
+++ b/usr/src/lib/libefi/Makefile.com
@@ -20,9 +20,8 @@
 #
 #
 # Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 # Use is subject to license terms.
-#
-# ident	"%Z%%M%	%I%	%E% SMI"
 #
 
 LIBRARY =	libefi.a
@@ -37,7 +36,7 @@ include ../../Makefile.rootfs
 SRCDIR =	../common
 
 LIBS =		$(DYNLIB) $(LINTLIB)
-LDLIBS +=	-luuid -lc
+LDLIBS +=	-luuid -lsmbios -lc
 $(LINTLIB) :=	SRCS = $(SRCDIR)/$(LINTSRC)
 CFLAGS +=	$(CCVERBOSE)
 

--- a/usr/src/man/man1m/fdisk.1m
+++ b/usr/src/man/man1m/fdisk.1m
@@ -1,26 +1,28 @@
 '\" te
 .\" Copyright (c) 2008, Sun Microsystems, Inc. All Rights Reserved
+.\" Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License. You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.
 .\"  See the License for the specific language governing permissions and limitations under the License. When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with
 .\" the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH FDISK 1M "Sep 10, 2013"
+.TH FDISK 1M "Feb 11, 2018"
 .SH NAME
 fdisk \- create or modify fixed disk partition table
 .SH SYNOPSIS
 .LP
 .nf
 \fBfdisk\fR [\fB-o\fR \fIoffset\fR] [\fB-s\fR \fIsize\fR] [\fB-P\fR \fIfill_patt\fR] [\fB-S\fR \fIgeom_file\fR]
-     [\fB-w\fR | \fB-r\fR | \fB-d\fR | \fB-n\fR | \fB-I\fR | \fB-B\fR | \fB-t\fR | \fB-T\fR | \fB-g\fR | \fB-G\fR | \fB-R\fR | \fB-E\fR]
+     [\fB-w\fR | \fB-r\fR | \fB-d\fR | \fB-n\fR | \fB-I\fR | \fB-B\fR | \fB-t\fR | \fB-T\fR | \fB-g\fR | \fB-G\fR | \fB-R\fR]
      [-\fB-F\fR \fIfdisk_file\fR] [ [\fB-v\fR] \fB-W\fR {\fIfdisk_file\fR | \(mi}]
      [\fB-h\fR] [\fB-b\fR \fImasterboot\fR]
      [\fB-A\fR \fIid\fR : \fIact\fR : \fIbhead\fR : \fIbsect\fR : \fIbcyl\fR : \fIehead\fR : \fIesect\fR :
          \fIecyl\fR : \fIrsect\fR : \fInumsect\fR]
      [\fB-D\fR \fIid\fR : \fIact\fR : \fIbhead:\fR \fIbsect\fR : \fIbcyl\fR : \fIehead:\fR \fIesect\fR :
          \fIecyl\fR : \fIrsect\fR : \fInumsect\fR] \fIrdevice\fR
+     [\fB-E\fR [\fIslot\fR : \fIactive\fR]]
+     \fIrdevice\fR
 .fi
 
 .SH DESCRIPTION
-.sp
 .LP
 This command is used to do the following:
 .RS +4
@@ -97,7 +99,6 @@ partition table, but the allocated disk space is not initialized.
 partition, and \fBformat\fR(1M) is required to write the VTOC or EFI/GPT
 metadata.
 .SS "Menu Options"
-.sp
 .LP
 The menu options for interactive mode given by the \fBfdisk\fR program are:
 .sp
@@ -270,7 +271,6 @@ This option exits without modifying the partition table.
 .RE
 
 .SH OPTIONS
-.sp
 .LP
 The following options apply to \fBfdisk\fR:
 .sp
@@ -336,11 +336,41 @@ Solaris partition if the \fBfdisk\fR table changes.
 .sp
 .ne 2
 .na
-\fB\fB-E\fR\fR
+\fB-E\fR [\fIslot\fR:\fIactive\fR]
 .ad
 .sp .6
 .RS 4n
 Create an \fBEFI\fR partition that uses the entire disk.
+.sp
+By default this partition entry will be placed into the first slot within the
+partition table and will not be marked active. The remaining slots within the
+table will be zeroed out.
+.sp
+Some broken firmware implementations have issues booting in CSM/Legacy/BIOS
+mode from EFI partitions that are not set active. Others have issues with
+booting from EFI partitions without UEFI if the protective partition table
+entry is in the first slot. To work around these problems, the \fB-E\fR
+option takes an optional argument which can be used to override the defaults
+described above.
+
+.sp
+.ne 2
+.na
+\fB\fIslot\fR\fR
+.ad
+.RS 11n
+Specify the MBR slot into which the EFI partition should be placed. This accepts a value in the range 0 to 3 with the default being 0.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fIactive\fR\fR
+.ad
+.RS 11n
+Specify whether the EFI partition entry should be marked active; \fB0\fR specifies not active (the default) and \fB1\fR means active.
+.RE
+
 .RE
 
 .sp
@@ -737,7 +767,6 @@ with the \fB-F\fR option below.
 .RE
 
 .SH FILES
-.sp
 .ne 2
 .na
 \fB\fB/dev/rdsk/c0t0d0p0\fR\fR
@@ -756,7 +785,6 @@ Default master boot program.
 .RE
 
 .SH ATTRIBUTES
-.sp
 .LP
 See \fBattributes\fR(5) for descriptions of the following attributes:
 .sp
@@ -772,12 +800,10 @@ Architecture	x86 and SPARC
 .TE
 
 .SH SEE ALSO
-.sp
 .LP
 \fBuname\fR(1), \fBfmthard\fR(1M), \fBformat\fR(1M), \fBnewfs\fR(1M),
 \fBprtvtoc\fR(1M), \fBattributes\fR(5)
 .SH DIAGNOSTICS
-.sp
 .LP
 Most messages will be self-explanatory. The following may appear immediately
 after starting the program:

--- a/usr/src/man/man3ext/efi_alloc_and_init.3ext
+++ b/usr/src/man/man3ext/efi_alloc_and_init.3ext
@@ -1,9 +1,10 @@
 '\" te
 .\" Copyright (c) 2008, Sun Microsystems, Inc. All Rights Reserved.
+.\" Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH EFI_ALLOC_AND_INIT 3EXT "April 9, 2016"
+.TH EFI_ALLOC_AND_INIT 3EXT "February 6, 2018"
 .SH NAME
 efi_alloc_and_init, efi_alloc_and_read, efi_free, efi_write, efi_use_whole_disk
 \- manipulate a disk's EFI Partition Table
@@ -55,7 +56,8 @@ The \fBefi_free()\fR function frees the memory allocated by
 \fBefi_alloc_and_init()\fR and \fBefi_alloc_and_read()\fR.
 .sp
 .LP
-The \fBefi_write()\fR function writes the EFI partition table.
+The \fBefi_write()\fR function writes the EFI partition table and creates a
+Protective Master Boot Record (PMBR); see below.
 .sp
 .LP
 The \fBefi_use_whole_disk()\fR function takes any space that is not contained
@@ -76,7 +78,7 @@ partition table and contains at least the following members:
 .in +2
 .nf
 uint_t          efi_version;     /* set to EFI_VERSION_CURRENT */
-uint_t          efi_nparts;      /* number of partitions in efi_parts */
+uint_t          efi_nparts;      /* no. of partitions in efi_parts */
 uint_t          efi_lbasize;     /* size of block in bytes */
 diskaddr_t      efi_last_lba;    /* last block on the disk */
 diskaddr_t      efi_first_u_lba; /* first block after labels */
@@ -84,6 +86,18 @@ diskaddr_t      efi_last_u_lba;  /* last block before backup labels */
 struct dk_part  efi_parts[];     /* array of partitions */
 .fi
 .in -2
+
+.SS "Protective Master Boot Record"
+.LP
+When a disk receives an EFI label, a protective MBR (\fBPMBR\fR) is also
+written containing a single partiton of type \fBEEh\fR and spanning the
+entire disk (up to the limit of what can be represented in an MBR). By
+default that partition is placed in slot 0 of the PMBR and not marked as
+active. Some BIOS implementations contain bugs that require the entry to be
+placed into a different slot or to be made active in order for the system
+to boot successfully. The default behaviour is modified for systems with known
+firmware bugs, refer to \fB/usr/share/hwdata/efi.fixes\fR for more
+information.
 
 .SH RETURN VALUES
 .LP

--- a/usr/src/pkg/manifests/system-data-hardware-registry.mf
+++ b/usr/src/pkg/manifests/system-data-hardware-registry.mf
@@ -21,6 +21,7 @@
 
 #
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 #
 
 set name=pkg.fmri value=pkg:/system/data/hardware-registry@$(PKGVERS)
@@ -33,10 +34,13 @@ set name=variant.arch value=$(ARCH)
 dir path=usr group=sys
 dir path=usr/share
 dir path=usr/share/hwdata group=sys
+file path=usr/share/hwdata/efi.fixes preserve=renamenew
 file path=usr/share/hwdata/pci.ids
 file path=usr/share/hwdata/usb.ids
 legacy pkg=SUNWhwdata \
     desc="ASCII databases describing various PCI, USB and other hardware" \
     name="Hardware data files"
+license usr/src/data/hwdata/THIRDPARTYLICENSE.efifixes \
+    license=usr/src/data/hwdata/THIRDPARTYLICENSE.efifixes
 license usr/src/data/hwdata/THIRDPARTYLICENSE.pciids \
     license=usr/src/data/hwdata/THIRDPARTYLICENSE.pciids


### PR DESCRIPTION
```
reaper# grep Dell /usr/share/hwdata/efi.fixes | tail -1
sys.manufacturer="Dell Inc." sys.product="PowerEdge R730" mb.version=A04 pmbr_active=1 pmbr_slot=3

reaper# zpool create test c0t13d1
reaper# fdisk -W - c0t13d1p0 | tail -5
* Id    Act  Bhead  Bsect  Bcyl    Ehead  Esect  Ecyl    Rsect      Numsect
  0     0    0      0      0       0      0      0       0          0
  0     0    0      0      0       0      0      0       0          0
  0     0    0      0      0       0      0      0       0          0
  238   128  255    63     1023    255    63     1023    1          62499999

reaper# zpool replace test c0t{13,14}d1
reaper# fdisk -W - c0t14d1p0 | tail -5
* Id    Act  Bhead  Bsect  Bcyl    Ehead  Esect  Ecyl    Rsect      Numsect
  0     0    0      0      0       0      0      0       0          0
  0     0    0      0      0       0      0      0       0          0
  0     0    0      0      0       0      0      0       0          0
  238   128  255    63     1023    255    63     1023    1          62499999

reaper# sed -i '/PowerEdge/s/active=1/active=0/' /usr/share/hwdata/efi.fixes
reaper# zpool replace test c0t{14,13}d1
reaper# fdisk -W - c0t13d1p0 | tail -5
* Id    Act  Bhead  Bsect  Bcyl    Ehead  Esect  Ecyl    Rsect      Numsect
  0     0    0      0      0       0      0      0       0          0
  0     0    0      0      0       0      0      0       0          0
  0     0    0      0      0       0      0      0       0          0
  238   0    255    63     1023    255    63     1023    1          62499999

reaper# sed -i '/PowerEdge/s/slot=3/slot=1/' /usr/share/hwdata/efi.fixes
reaper# zpool replace test c0t{13,14}d1
reaper# fdisk -W - c0t14d1p0 | tail -5
* Id    Act  Bhead  Bsect  Bcyl    Ehead  Esect  Ecyl    Rsect      Numsect
  0     0    0      0      0       0      0      0       0          0
  238   0    255    63     1023    255    63     1023    1          62499999
  0     0    0      0      0       0      0      0       0          0
  0     0    0      0      0       0      0      0       0          0

reaper# sed -i '/PowerEdge/s/^/#/' /usr/share/hwdata/efi.fixes
reaper# zpool replace test c0t{14,13}d1
reaper# fdisk -W - c0t13d1p0 | tail -5
* Id    Act  Bhead  Bsect  Bcyl    Ehead  Esect  Ecyl    Rsect      Numsect
  238   0    255    63     1023    255    63     1023    1          62499999
  0     0    0      0      0       0      0      0       0          0
  0     0    0      0      0       0      0      0       0          0
  0     0    0      0      0       0      0      0       0          0
```

```
reaper# zpool export test
reaper# fdisk -E 2:1 c0t13d1p0
reaper# fdisk -W - c0t13d1p0 | tail -5
* Id    Act  Bhead  Bsect  Bcyl    Ehead  Esect  Ecyl    Rsect      Numsect
  0     0    0      0      0       0      0      0       0          0
  0     0    0      0      0       0      0      0       0          0
  238   128  255    63     1023    255    63     1023    1          62499999
  0     0    0      0      0       0      0      0       0          0
reaper# zpool import test
reaper# zpool status test
  pool: test
 state: ONLINE
  scan: resilvered 86K in 0h0m with 0 errors on Mon Feb 12 10:46:49 2018
config:

        NAME        STATE     READ WRITE CKSUM
        test        ONLINE       0     0     0
          c0t13d1   ONLINE       0     0     0

errors: No known data errors
```