### PR TITLE
Upstream DelphixOS fixes for libumem

### DIFF
--- a/usr/src/cmd/boot/bootadm/Makefile
+++ b/usr/src/cmd/boot/bootadm/Makefile
@@ -43,7 +43,7 @@ POFILE= bootadm_cmd.po
 .KEEP_STATE:
 
 LDLIBS_i386= -lfdisk
-LDLIBS += -lficl-sys -lmd -lcryptoutil -lnvpair -lgen -ladm -lefi
+LDLIBS += -lumem -lficl-sys -lmd -lcryptoutil -lnvpair -lgen -ladm -lefi
 LDLIBS += -lscf -lz -lbe -lzfs -lofmt $(LDLIBS_$(MACH))
 
 # Writing into string literals is incorrect.  We need to match gcc's

--- a/usr/src/cmd/chown/Makefile
+++ b/usr/src/cmd/chown/Makefile
@@ -24,6 +24,8 @@
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
 
 PROG= chown
 XPG4PROG= chown
@@ -35,7 +37,7 @@ include ../Makefile.cmd
 
 $(XPG4) :=	CFLAGS += -DXPG4
 CPPFLAGS += -D_FILE_OFFSET_BITS=64
-LDLIBS += -lcmdutils -lsec
+LDLIBS += -lumem -lcmdutils -lsec
 
 .KEEP_STATE:
 

--- a/usr/src/cmd/fm/fmadm/Makefile.com
+++ b/usr/src/cmd/fm/fmadm/Makefile.com
@@ -22,6 +22,8 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
 
 .KEEP_STATE:
 .SUFFIXES:
@@ -43,7 +45,7 @@ $(NOT_RELEASE_BUILD)CPPFLAGS += -DDEBUG
 CPPFLAGS += -I. -I../common
 CFLAGS += $(CTF_FLAGS) $(CCVERBOSE) $(XSTRCONST)
 LDLIBS += -L$(ROOT)/usr/lib/fm -lfmd_adm -lfmd_msg
-LDLIBS += -lnvpair -ltopo
+LDLIBS += -lumem -lnvpair -ltopo
 LDFLAGS += -R/usr/lib/fm
 LINTFLAGS += -mnu
 

--- a/usr/src/cmd/fm/fmdump/Makefile.com
+++ b/usr/src/cmd/fm/fmdump/Makefile.com
@@ -20,6 +20,7 @@
 #
 #
 # Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017 by Delphix. All rights reserved.
 #
 
 .KEEP_STATE:
@@ -35,7 +36,7 @@ ROOTPROG = $(ROOTUSRSBIN)/$(PROG)
 $(NOT_RELEASE_BUILD)CPPFLAGS += -DDEBUG
 CPPFLAGS += -I. -I../common -I../../include
 CFLAGS += $(CTF_FLAGS) $(CCVERBOSE) $(XSTRCONST)
-LDLIBS += -L$(ROOT)/usr/lib/fm -lfmd_log -lnvpair -ltopo -lfmd_msg
+LDLIBS += -L$(ROOT)/usr/lib/fm -lumem -lfmd_log -lnvpair -ltopo -lfmd_msg
 LDFLAGS += -R/usr/lib/fm
 LINTFLAGS += -mnu
 CERRWARN += -_gcc=-Wno-parentheses

--- a/usr/src/cmd/fm/fmstat/Makefile.com
+++ b/usr/src/cmd/fm/fmstat/Makefile.com
@@ -22,6 +22,7 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright (c) 2017 by Delphix. All rights reserved
 # Copyright (c) 2018, Joyent, Inc.
 
 .KEEP_STATE:
@@ -44,7 +45,7 @@ LINTFILES += $(STAT_LINTFILES)
 $(NOT_RELEASE_BUILD)CPPFLAGS += -DDEBUG
 CPPFLAGS += -I. -I../common -I$(STATCOMMONDIR)
 CFLAGS += $(CTF_FLAGS) $(CCVERBOSE) $(XSTRCONST)
-LDLIBS += -L$(ROOT)/usr/lib/fm -lfmd_adm
+LDLIBS += -L$(ROOT)/usr/lib/fm -lfmd_adm -lumem
 LDFLAGS += -R/usr/lib/fm
 LINTFLAGS += -mnu
 

--- a/usr/src/cmd/fm/fmtopo/Makefile.com
+++ b/usr/src/cmd/fm/fmtopo/Makefile.com
@@ -24,6 +24,7 @@
 # Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright (c) 2017 by Delphix. All rights reserved
 # Copyright (c) 2018, Joyent, Inc.
 
 .KEEP_STATE:
@@ -41,7 +42,7 @@ ROOTPROG = $(ROOTLIBFMD)/$(PROG)
 $(NOT_RELEASE_BUILD)CPPFLAGS += -DDEBUG
 CPPFLAGS += -I. -I../common
 CFLAGS += $(CTF_FLAGS) $(CCVERBOSE) $(XSTRCONST)
-LDLIBS += -L$(ROOT)/usr/lib/fm -ltopo -lnvpair
+LDLIBS += -L$(ROOT)/usr/lib/fm -ltopo -lnvpair -lumem
 LDFLAGS += -R/usr/lib/fm
 LINTFLAGS += -mnu
 

--- a/usr/src/lib/libumem/common/vmem.c
+++ b/usr/src/lib/libumem/common/vmem.c
@@ -23,6 +23,7 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2012 Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -458,12 +459,12 @@ vmem_span_create(vmem_t *vmp, void *vaddr, size_t size, uint8_t import)
 
 	span = vmem_seg_create(vmp, knext->vs_aprev, start, end);
 	span->vs_type = VMEM_SPAN;
+	span->vs_import = import;
 	VMEM_INSERT(knext->vs_kprev, span, k);
 
 	newseg = vmem_seg_create(vmp, span, start, end);
 	vmem_freelist_insert(vmp, newseg);
 
-	newseg->vs_import = import;
 	if (import)
 		vmp->vm_kstat.vk_mem_import += size;
 	vmp->vm_kstat.vk_mem_total += size;
@@ -483,7 +484,7 @@ vmem_span_destroy(vmem_t *vmp, vmem_seg_t *vsp)
 	ASSERT(MUTEX_HELD(&vmp->vm_lock));
 	ASSERT(span->vs_type == VMEM_SPAN);
 
-	if (vsp->vs_import)
+	if (span->vs_import)
 		vmp->vm_kstat.vk_mem_import -= size;
 	vmp->vm_kstat.vk_mem_total -= size;
 
@@ -686,7 +687,8 @@ vmem_advance(vmem_t *vmp, vmem_seg_t *walker, vmem_seg_t *afterme)
 	 * vsp could represent a complete imported span,
 	 * in which case we must return it to the source.
 	 */
-	if (vsp != NULL && vsp->vs_import && vmp->vm_source_free != NULL &&
+	if (vsp != NULL && vsp->vs_aprev->vs_import &&
+	    vmp->vm_source_free != NULL &&
 	    vsp->vs_aprev->vs_type == VMEM_SPAN &&
 	    vsp->vs_anext->vs_type == VMEM_SPAN) {
 		void *vaddr = (void *)vsp->vs_start;
@@ -813,7 +815,7 @@ vmem_nextfit_alloc(vmem_t *vmp, size_t size, int vmflag)
  */
 void *
 vmem_xalloc(vmem_t *vmp, size_t size, size_t align, size_t phase,
-	size_t nocross, void *minaddr, void *maxaddr, int vmflag)
+    size_t nocross, void *minaddr, void *maxaddr, int vmflag)
 {
 	vmem_seg_t *vsp;
 	vmem_seg_t *vbest = NULL;
@@ -1040,7 +1042,7 @@ vmem_xfree(vmem_t *vmp, void *vaddr, size_t size)
 	/*
 	 * If the entire span is free, return it to the source.
 	 */
-	if (vsp->vs_import && vmp->vm_source_free != NULL &&
+	if (vsp->vs_aprev->vs_import && vmp->vm_source_free != NULL &&
 	    vsp->vs_aprev->vs_type == VMEM_SPAN &&
 	    vsp->vs_anext->vs_type == VMEM_SPAN) {
 		vaddr = (void *)vsp->vs_start;
@@ -1364,7 +1366,7 @@ _vmem_extend_alloc(vmem_t *vmp, void *vaddr, size_t size, size_t alloc,
  */
 void
 vmem_walk(vmem_t *vmp, int typemask,
-	void (*func)(void *, void *, size_t), void *arg)
+    void (*func)(void *, void *, size_t), void *arg)
 {
 	vmem_seg_t *vsp;
 	vmem_seg_t *seg0 = &vmp->vm_seg0;
@@ -1428,8 +1430,8 @@ vmem_size(vmem_t *vmp, int typemask)
  */
 vmem_t *
 vmem_create(const char *name, void *base, size_t size, size_t quantum,
-	vmem_alloc_t *afunc, vmem_free_t *ffunc, vmem_t *source,
-	size_t qcache_max, int vmflag)
+    vmem_alloc_t *afunc, vmem_free_t *ffunc, vmem_t *source,
+    size_t qcache_max, int vmflag)
 {
 	int i;
 	size_t nqcache;


### PR DESCRIPTION
First patch is arbitrary, it compiles some more programs with libumem. We could decide to drop that one. The seconds one is more important as it fixes a problem in libumem. I compared the content of libumem against the same directory in delphix-os gate and its exactly the same after this patch so there are no other patches applied to it.