### PR TITLE
Re-align brand_clearbrand with upstream gate.

### DIFF
--- a/usr/src/uts/common/brand/lx/os/lx_brand.c
+++ b/usr/src/uts/common/brand/lx/os/lx_brand.c
@@ -26,7 +26,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
- * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
  * Copyright 2024 MNX Cloud, Inc.
  * Copyright 2025 Edgecast Cloud LLC.
  */
@@ -349,6 +349,13 @@ lx_proc_exit(proc_t *p)
 	lx_proc_data_t *lxpd;
 	proc_t *cp;
 
+	/*
+	 * This runs down the last LWP of the exiting process. That LWP is
+	 * still attached here (b_proc_exit fires before the final LWP is
+	 * detached) so the process still has an LWP of its own and no_lwps
+	 * is false. This matches the other single-LWP caller, the successful
+	 * native exec path through brand_clearbrand().
+	 */
 	lx_clone_grp_exit(p, B_FALSE);
 	/* Cleanup any outstanding aio contexts */
 	lx_io_cleanup(p);
@@ -577,9 +584,9 @@ lx_pagefault(proc_t *p, klwp_t *lwp, caddr_t addr, enum fault_type type,
 #endif
 
 static void
-lx_clearbrand(proc_t *p, boolean_t lwps_ok)
+lx_clearbrand(proc_t *p, boolean_t no_lwps)
 {
-	lx_clone_grp_exit(p, lwps_ok);
+	lx_clone_grp_exit(p, no_lwps);
 }
 
 /*

--- a/usr/src/uts/common/brand/lx/syscall/lx_clone.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_clone.c
@@ -22,6 +22,7 @@
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2016 Joyent, Inc.
+ * Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -279,7 +280,7 @@ lx_clone_grp_enter(uint_t flags, proc_t *srcp, proc_t *dstp)
  * be de-branded).
  */
 void
-lx_clone_grp_exit(proc_t *p, boolean_t lwps_ok)
+lx_clone_grp_exit(proc_t *p, boolean_t no_lwps)
 {
 	int i;
 	lx_proc_data_t *plproc = ptolxproc(p);
@@ -288,7 +289,11 @@ lx_clone_grp_exit(proc_t *p, boolean_t lwps_ok)
 	ASSERT(!MUTEX_HELD(&p->p_lock));
 	ASSERT(plproc != NULL);
 
-	if (!lwps_ok)
+	/*
+	 * If the caller has told us the process has no running LWPs of its
+	 * own, the list must be down to at most one LWP.
+	 */
+	if (no_lwps)
 		VERIFY(p->p_lwpcnt <= 1);
 
 	cgps = plproc->l_clone_grps;

--- a/usr/src/uts/common/os/brand.c
+++ b/usr/src/uts/common/os/brand.c
@@ -314,7 +314,7 @@ brand_unregister_zone(struct brand *bp)
 }
 
 int
-brand_setbrand(proc_t *p, boolean_t lwps_ok)
+brand_setbrand(proc_t *p, boolean_t no_lwps)
 {
 	brand_t *bp = p->p_zone->zone_brand;
 	void *brand_data = NULL;
@@ -343,7 +343,12 @@ brand_setbrand(proc_t *p, boolean_t lwps_ok)
 	 * they are killed in the exec() success, or when the brand is cleared
 	 * after exec() failure.
 	 */
-	if (lwps_ok) {
+	if (no_lwps) {
+		/*
+		 * Processes branded during fork() should not have LWPs at all.
+		 */
+		VERIFY(p->p_tlist == NULL);
+	} else {
 		/*
 		 * We've been called from a exec() context tolerating the
 		 * existence of multiple LWPs during branding is necessary.
@@ -359,11 +364,6 @@ brand_setbrand(proc_t *p, boolean_t lwps_ok)
 				return (-1);
 			}
 		}
-	} else {
-		/*
-		 * Processes branded during fork() should not have LWPs at all.
-		 */
-		VERIFY(p->p_tlist == NULL);
 	}
 
 	if (bp->b_data_size > 0) {
@@ -381,7 +381,7 @@ brand_setbrand(proc_t *p, boolean_t lwps_ok)
 }
 
 void
-brand_clearbrand(proc_t *p, boolean_t lwps_ok)
+brand_clearbrand(proc_t *p, boolean_t no_lwps)
 {
 	brand_t *bp = p->p_zone->zone_brand;
 	void *brand_data;
@@ -391,31 +391,31 @@ brand_clearbrand(proc_t *p, boolean_t lwps_ok)
 	VERIFY(PROC_IS_BRANDED(p));
 
 	if (BROP(p)->b_clearbrand != NULL)
-		BROP(p)->b_clearbrand(p, lwps_ok);
+		BROP(p)->b_clearbrand(p, no_lwps);
 
 	mutex_enter(&p->p_lock);
 	p->p_brand = &native_brand;
 	brand_data = p->p_brand_data;
 	p->p_brand_data = NULL;
 
-	if (lwps_ok) {
+	if (no_lwps) {
+		/*
+		 * The brand is being cleared on a process with no LWPs of its
+		 * own running: the child of a failed fork, or a zombie being
+		 * reaped in freeproc().  At most one LWP may remain on the list.
+		 */
+		VERIFY(p->p_tlist == NULL || p->p_tlist == p->p_tlist->t_forw);
+	} else {
 		VERIFY(p == curproc);
 		/*
-		 * A process with multiple LWPs is being de-branded after
-		 * failing an exec.  The other LWPs were held as part of the
-		 * procedure, so they must be resumed now.
+		 * The brand is being cleared on curproc during exec.  If an
+		 * exec failed after the other LWPs were held, a process with
+		 * multiple LWPs is being de-branded and those LWPs must be
+		 * resumed now.
 		 */
 		if (p->p_tlist != NULL && p->p_tlist != p->p_tlist->t_forw) {
 			continuelwps(p);
 		}
-	} else {
-		/*
-		 * While clearing the brand, it's ok for one LWP to be present.
-		 * This happens when a native binary is executed inside a
-		 * branded zone, since the brand will be removed during the
-		 * course of a successful exec.
-		 */
-		VERIFY(p->p_tlist == NULL || p->p_tlist == p->p_tlist->t_forw);
 	}
 	mutex_exit(&p->p_lock);
 

--- a/usr/src/uts/common/os/exec.c
+++ b/usr/src/uts/common/os/exec.c
@@ -29,6 +29,7 @@
  * Copyright 2015 Garrett D'Amore <garrett@damore.org>
  * Copyright 2019 Joyent, Inc.
  * Copyright 2024 Oxide Computer Company
+ * Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
  */
 
 #include <sys/types.h>
@@ -409,7 +410,7 @@ exec_common(const char *fname, const char **argp, const char **envp,
 		 * Process branding may fail if multiple LWPs are present and
 		 * holdlwps() cannot complete successfully.
 		 */
-		error = brand_setbrand(p, B_TRUE);
+		error = brand_setbrand(p, B_FALSE);
 
 		if (error == 0 && BROP(p)->b_lwpdata_alloc != NULL) {
 			brand_data = BROP(p)->b_lwpdata_alloc(p);
@@ -436,7 +437,7 @@ exec_common(const char *fname, const char **argp, const char **envp,
 	    exec_file, p->p_cred, &brand_action)) != 0) {
 		if (brandme) {
 			BROP(p)->b_freelwp(lwp);
-			brand_clearbrand(p, B_TRUE);
+			brand_clearbrand(p, B_FALSE);
 		}
 		VN_RELE(vp);
 		if (dir != NULL)

--- a/usr/src/uts/common/os/exit.c
+++ b/usr/src/uts/common/os/exit.c
@@ -23,7 +23,7 @@
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2018 Joyent, Inc.
  * Copyright 2020 Oxide Computer Company
- * Copyright 2021 OmniOS Community Edition (OmniOSce) Association.
+ * Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -1468,7 +1468,7 @@ freeproc(proc_t *p)
 
 	/* Clear any remaining brand data */
 	if (PROC_IS_BRANDED(p)) {
-		brand_clearbrand(p, B_FALSE);
+		brand_clearbrand(p, B_TRUE);
 	}
 
 

--- a/usr/src/uts/common/os/fork.c
+++ b/usr/src/uts/common/os/fork.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016, Joyent, Inc.
+ * Copyright 2026 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -707,7 +708,7 @@ fork_fail(proc_t *cp)
 	if (PTOU(curproc)->u_cwd)
 		refstr_rele(PTOU(curproc)->u_cwd);
 	if (PROC_IS_BRANDED(cp)) {
-		brand_clearbrand(cp, B_FALSE);
+		brand_clearbrand(cp, B_TRUE);
 	}
 }
 
@@ -1198,7 +1199,7 @@ getproc(proc_t **cpp, pid_t pid, uint_t flags)
 		 * With an LWP count of 0, this newly allocated process has no
 		 * reason to fail branding.
 		 */
-		VERIFY0(brand_setbrand(cp, B_FALSE));
+		VERIFY0(brand_setbrand(cp, B_TRUE));
 
 		BROP(pp)->b_copy_procdata(cp, pp);
 	}


### PR DESCRIPTION
The signature of the `brand_clearbrand()` function has diverged
from gate and this extends into common code, making merges
trickier and more prone to error. Switch to the gate variant
which has very slightly different semantics, and restore common
shared code back to that which is in gate.

Our variant arrived via:
  OS-4460 exec brands processes that still have multiple threads
whereas gate's was:
  6859073 kmem leak in kmem_alloc_64 in case of fork failures in branded zones
